### PR TITLE
Adding a param for run-build-and-deploy-main

### DIFF
--- a/wp-build-hooks.php
+++ b/wp-build-hooks.php
@@ -405,6 +405,7 @@ function add_hook_actions() {
 			$options['json'] = [
 				'parameters' => [
 					'run-build-and-deploy-master' => false,
+					'run-build-and-deploy-main' => false,
 					'run-build-and-deploy-pr'     => false,
 					'run-build-and-deploy-mu'     => false,
 					'run-deploy-test-to-live'     => true,


### PR DESCRIPTION
We're switching our example repos to use `main` instead of `master`. Reviewing this PR should probably be done in conjunction with https://github.com/pantheon-systems/gatsby-wordpress-demo/issues/24